### PR TITLE
Fixed wrong raycaster.intersectObjects parameter

### DIFF
--- a/exercises/06_Detecting_Mouse_Clicks/problem.md
+++ b/exercises/06_Detecting_Mouse_Clicks/problem.md
@@ -41,7 +41,7 @@ var raycaster = new THREE.Raycaster(camera.position, vector.sub(camera.position)
 This will give us a collection of intersections that we can iterate through to look at any objects we are interested in:
 
 ```js
-var intersects = raycaster.intersectObjects(objects);
+var intersects = raycaster.intersectObjects(scene.children);
 ```
 
 And to illustrate the click has occurred we will change the colour of the object:


### PR DESCRIPTION
The 6th lesson wasn't working, because your raycaster.intersectObjects function took a variable "objects" as parameter, which doesn't exist. It's fixed by changing it to scene.children.